### PR TITLE
fix: verify fails

### DIFF
--- a/pymockserver/client.py
+++ b/pymockserver/client.py
@@ -114,8 +114,8 @@ class Client(object):
             data['times'] = vars(times)
         else:
             data['times'] = {
-                'count': 1,
-                'exact': True
+                'atLeast': 1,
+                'atMost': 1
             }
         req = requests.put('{}/verify'.format(self._get_url()),
                            headers=self.headers,

--- a/pymockserver/times.py
+++ b/pymockserver/times.py
@@ -18,5 +18,6 @@ class VerificationTimes(object):
     """
 
     def __init__(self, count=1, exact=True):
-        self.count = count
-        self.exact = exact
+        self.atLeast = count
+        if exact:
+            self.atMost = count

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -123,8 +123,7 @@ class ClientTest(TestCase):
         data = {
             'httpRequest': request.dict(),
             'times': {
-                'count': 2,
-                'exact': False
+                'atLeast': 2
             }
         }
         mocked.assert_called_with('{}/verify'.format(self.base_url),
@@ -139,8 +138,8 @@ class ClientTest(TestCase):
         data = {
             'httpRequest': request.dict(),
             'times': {
-                'count': 1,
-                'exact': True
+                'atLeast': 1,
+                'atMost': 1
             }
         }
         mocked.assert_called_with('{}/verify'.format(self.base_url),

--- a/tests/times_test.py
+++ b/tests/times_test.py
@@ -19,10 +19,10 @@ class VerificationTimesTest(TestCase):
 
     def test_init_default(self):
         times = VerificationTimes()
-        self.assertEqual(1, times.count)
-        self.assertTrue(times.exact)
+        self.assertEqual(1, times.atLeast)
+        self.assertEqual(1, times.atMost)
 
     def test_init_with_value(self):
         times = VerificationTimes(count=2, exact=False)
-        self.assertEqual(2, times.count)
-        self.assertFalse(times.exact)
+        self.assertEqual(2, times.atLeast)
+        self.assertFalse(hasattr(times, "atMost"))


### PR DESCRIPTION
"count" and "exact" are no longer properties of the times object for /mockserver/verify. Instead the properties "atLeast" and "atMost" should be used

closes: #6

This pull request fixes all unit and integration tests